### PR TITLE
usersテーブルの追加とその他テーブルの命名変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: up up-d up-build down stop psql exec-db exec-be schema seed
+
 up:
 	docker-compose up
 

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,11 @@ exec-db:
 exec-be:
 	docker exec -it chasaji-backend bash
 
+# スキーマの更新を適用
+schema:
+	docker exec -it chasaji-db psql -U postgres -d learn -f /docker-entrypoint-initdb.d/schema_definition.sql
+
+# シードデータの適用
+seed:
+	docker exec -it chasaji-db psql -U postgres -d learn -f /docker-entrypoint-initdb.d/seed_data.sql
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,1 @@
-#databaseのURLを入れて！！！！！！！！！！！！！
-DATABASE_URL=
+DATABASE_URL=postgresql://postgres:sajisaji@db:5432/learn

--- a/backend/models.py
+++ b/backend/models.py
@@ -6,11 +6,11 @@ from database import Base  # Base はあなたが定義した declarative_base()
 
 
 class Blog(Base):
-    __tablename__ = "blog"
+    __tablename__ = "blogs"
     __table_args__ = {"schema": "public"}  # スキーマ指定（必要なら）
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_sub = Column(UUID(as_uuid=True), nullable=False)
+    user_id = Column(UUID(as_uuid=True), nullable=False)
     title = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
     created_at = Column(

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, TIMESTAMP, func
+from sqlalchemy import Column, String, Text, TIMESTAMP, func, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
 
@@ -10,7 +10,7 @@ class Blog(Base):
     __table_args__ = {"schema": "public"}  # スキーマ指定（必要なら）
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(UUID(as_uuid=True), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey('public.users.id'), nullable=False)
     title = Column(String(255), nullable=False)
     content = Column(Text, nullable=False)
     created_at = Column(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 class Blog(BaseModel):
     id: UUID
-    user_sub: UUID
+    user_id: UUID
     title: str
     content: str
     created_at: datetime

--- a/db/init/schema_definition.sql
+++ b/db/init/schema_definition.sql
@@ -1,8 +1,18 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE public.blog (
+CREATE TABLE IF NOT EXISTS public.users (
+    id UUID PRIMARY KEY,
+    preferred_username VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    profile TEXT,
+    picture TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS public.blog (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_sub UUID NOT NULL,
+    user_id UUID NOT NULL REFERENCES public.users(id),
     title VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -18,7 +28,14 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- トリガー登録
+-- トリガー登録（既存のトリガーを削除してから再作成）
+DROP TRIGGER IF EXISTS set_timestamp ON public.users;
+CREATE TRIGGER  set_timestamp
+BEFORE UPDATE ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_timestamp();
+
+DROP TRIGGER IF EXISTS set_timestamp ON public.blog;
 CREATE TRIGGER set_timestamp
 BEFORE UPDATE ON public.blog
 FOR EACH ROW

--- a/db/init/schema_definition.sql
+++ b/db/init/schema_definition.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE IF NOT EXISTS public.users (
+CREATE TABLE public.users (
     id UUID PRIMARY KEY,
     preferred_username VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS public.users (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS public.blog (
+CREATE TABLE public.blogs (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     user_id UUID NOT NULL REFERENCES public.users(id),
     title VARCHAR(255) NOT NULL,
@@ -28,15 +28,13 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- トリガー登録（既存のトリガーを削除してから再作成）
-DROP TRIGGER IF EXISTS set_timestamp ON public.users;
+-- トリガー登録
 CREATE TRIGGER  set_timestamp
 BEFORE UPDATE ON public.users
 FOR EACH ROW
 EXECUTE FUNCTION trigger_set_timestamp();
 
-DROP TRIGGER IF EXISTS set_timestamp ON public.blog;
 CREATE TRIGGER set_timestamp
-BEFORE UPDATE ON public.blog
+BEFORE UPDATE ON public.blogs
 FOR EACH ROW
 EXECUTE FUNCTION trigger_set_timestamp();

--- a/db/init/seed_data.sql
+++ b/db/init/seed_data.sql
@@ -1,6 +1,11 @@
 -- シードデータ挿入
+INSERT INTO public.users (id, preferred_username, email, profile, picture)
+VALUES 
+  ('3476fd9a-0387-49f9-82fd-7c33dcdbb315', 'user1', 'user1@example.com', '初めてのユーザーです', 'https://example.com/profile1.jpg'),
+  ('4476fd9a-0387-49f9-82fd-7c33dcdbb316', 'user2', 'user2@example.com', '2番目のユーザーです', 'https://example.com/profile2.jpg');
+
 INSERT INTO public.blog (id, user_sub, title, content, created_at, updated_at)
 VALUES 
-  (uuid_generate_v4(), uuid_generate_v4(), '初めてのブログ', '## これは最初の投稿です。\nMarkdown形式で書かれています。', '2025-04-01 10:00:00+09', '2025-04-01 10:00:00+09'),
-  (uuid_generate_v4(), uuid_generate_v4(), '技術ブログ', '### PostgreSQLとPL/pgSQLについて語る回。\nかなり奥が深いです。', '2025-04-05 09:30:00+09', '2025-04-05 09:30:00+09'),
-  (uuid_generate_v4(), uuid_generate_v4(), '旅の記録', '#### 京都の桜がきれいだった話\n![桜の画像](https://example.com/sakura.jpg)', '2025-04-07 18:45:00+09', '2025-04-07 18:45:00+09');
+  (uuid_generate_v4(), '3476fd9a-0387-49f9-82fd-7c33dcdbb315', '初めてのブログ', '## これは最初の投稿です。\nMarkdown形式で書かれています。', '2025-04-01 10:00:00+09', '2025-04-01 10:00:00+09'),
+  (uuid_generate_v4(), '3476fd9a-0387-49f9-82fd-7c33dcdbb315', '技術ブログ', '### PostgreSQLとPL/pgSQLについて語る回。\nかなり奥が深いです。', '2025-04-05 09:30:00+09', '2025-04-05 09:30:00+09'),
+  (uuid_generate_v4(), '4476fd9a-0387-49f9-82fd-7c33dcdbb316', '旅の記録', '#### 京都の桜がきれいだった話\n![桜の画像](https://example.com/sakura.jpg)', '2025-04-07 18:45:00+09', '2025-04-07 18:45:00+09');

--- a/db/init/seed_data.sql
+++ b/db/init/seed_data.sql
@@ -4,7 +4,7 @@ VALUES
   ('3476fd9a-0387-49f9-82fd-7c33dcdbb315', 'user1', 'user1@example.com', '初めてのユーザーです', 'https://example.com/profile1.jpg'),
   ('4476fd9a-0387-49f9-82fd-7c33dcdbb316', 'user2', 'user2@example.com', '2番目のユーザーです', 'https://example.com/profile2.jpg');
 
-INSERT INTO public.blog (id, user_sub, title, content, created_at, updated_at)
+INSERT INTO public.blogs (id, user_id, title, content, created_at, updated_at)
 VALUES 
   (uuid_generate_v4(), '3476fd9a-0387-49f9-82fd-7c33dcdbb315', '初めてのブログ', '## これは最初の投稿です。\nMarkdown形式で書かれています。', '2025-04-01 10:00:00+09', '2025-04-01 10:00:00+09'),
   (uuid_generate_v4(), '3476fd9a-0387-49f9-82fd-7c33dcdbb315', '技術ブログ', '### PostgreSQLとPL/pgSQLについて語る回。\nかなり奥が深いです。', '2025-04-05 09:30:00+09', '2025-04-05 09:30:00+09'),

--- a/docs/er.md
+++ b/docs/er.md
@@ -6,16 +6,16 @@ erDiagram
         string email UK
         string profile "プロフィール文"
         text picture "プロフィール画像"
-        date created_at "作成日"
-        date updated_at "更新日"
+        timestamp created_at "作成日"
+        timestamp updated_at "更新日"
     }
     blogs {
         uuid id PK "ブログID"
         uuid user_id
         string title "タイトル"
         string content "mdを保存 文章"
-        date created_at "作成日"
-        date updated_at "更新日"
+        timestamp created_at "作成日"
+        timestamp updated_at "更新日"
     }
 
     users 1--0+ blogs : ""

--- a/docs/er.md
+++ b/docs/er.md
@@ -1,20 +1,22 @@
 ```mermaid
 erDiagram
-    cognito_user {
-        int sub PK "UUID"
+    users {
+        uuid id PK "cognitoで管理されるsub"
         string preferred_username "ハンドルネーム"
         string email UK
         string profile "プロフィール文"
-        int picture "プロフィール画像"
+        text picture "プロフィール画像"
+        date created_at "作成日"
+        date updated_at "更新日"
     }
-    blog {
-        int id PK "ブログID（UUID）"
-        int user_sub "cognito_userのsub"
+    blogs {
+        uuid id PK "ブログID"
+        uuid user_id
         string title "タイトル"
         string content "mdを保存 文章"
         date created_at "作成日"
         date updated_at "更新日"
     }
 
-    cognito_user 1--0+ blog : ""
+    users 1--0+ blogs : ""
 ```


### PR DESCRIPTION
## チケット
- #33 

## 変更内容
- `cognito-user`としていたテーブルを、`users`テーブルとして作成するためのSQLの作成
  - seedデータの作成
- docker上のdbにスキーマを反映させるための`schema`とseedデータを流し込むための`seed`コマンドを作成（それぞれ`make ***`で動作）
- テーブルとカラムの命名を変更
  - 具体的な変更
    - テーブル名：単数系→複数系
    - カラム（外部キー）：`テーブル名の単数系_id`
  - それに伴って`python`のモデル部分の実装を修正

## 確認方法
本来テーブルのスキーマの更新等はマイグレーションという操作が必要ですが、その管理方法について定めてなかったので、まだ実データを扱っていないので、以下の手順で一度ボリュームを`docker`上から削除して再度生成する方針でお願いできればと思います。（参考：[マイグレーションとはのわかりやすかった記事](https://qiita.com/kotobuki5991/items/c427faaa4b4e3e58d316)）

1. コンテナの削除
  ```shell
  docker-comopse down
  # or
  make down
  ```
2. ボリュームの削除（DBの削除）
  ```shell
  docker volume rm chasaji-test_postgres-data
  ```
3. コンテナのビルド＆起動（初回起動時のみテーブルの生成とシードデータの流し込みが行われる）
  ```shell
  docker-compose up
  # or
  make up
  ```

## レビュー項目
- usersテーブル、blogsテーブルが作成され、シードデータが登録されていることの確認
  - 下記でpsqlでDBサーバに入って`select * from users;`, `select * from blogs;`などを行って確認してください。
    ```
    make psql
    ```
- er図とテーブルのスキーマ定義の整合性が取れているかの確認
  - `docs/er.md`の内容が作成したテーブルと整合性が取れているか確認してください。
- APIアプリのデグレーションのないことの確認
  - `blogs`エンドポイント（http://localhost:8000/blogs/ ） にリクエストを送って、DBのブログ情報が取得できることを確認してください。