### PR TITLE
CIの起動トリガーをmainへのpushからPR作成・更新時に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 # GitHub Actions CI template: Lint とテストを自動実行します
 name: CI
 
-# main ブランチへのプッシュで動作
+# PRの作成で動作
 on:
-  push:
-    branches: [ main ]
+  pull_request:
 
 jobs:
   # JavaScript/TypeScript 用ジョブ（Prettier, ESLint, テスト）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # GitHub Actions CI template: Lint とテストを自動実行します
 name: CI
 
-# PRの作成で動作
+# PRの作成・更新で動作
 on:
   pull_request:
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,8 +6,16 @@ import pluginPrettier from 'eslint-plugin-prettier';
 import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
-  js.configs.recommended, //  Flat Config ではこう書く
-
+  {
+    ignores: [
+      'node_modules/**',
+      'dist/**',
+      'build/**',
+      'coverage/**',
+      '.git/**',
+    ],
+  },
+  js.configs.recommended,
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -27,6 +27,11 @@ export default defineConfig([
     plugins: {
       prettier: pluginPrettier,
     },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
     rules: {
       'prettier/prettier': 'error',
       'react/react-in-jsx-scope': 'off',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,15 +2,16 @@ import { useState, useEffect } from 'react';
 import reactLogo from './assets/react.svg';
 import viteLogo from '/vite.svg';
 import './App.css';
-import { useAuth } from "react-oidc-context";
+import { useAuth } from 'react-oidc-context';
 
 function App() {
   const auth = useAuth();
 
   const signOutRedirect = () => {
-    const clientId = "6853gvj2etkjscvolje3mnrifc";
-    const logoutUri = "http://localhost:5173/";
-    const cognitoDomain = "https://ap-northeast-1govy1nd3f.auth.ap-northeast-1.amazoncognito.com";
+    const clientId = '6853gvj2etkjscvolje3mnrifc';
+    const logoutUri = 'http://localhost:5173/';
+    const cognitoDomain =
+      'https://ap-northeast-1govy1nd3f.auth.ap-northeast-1.amazoncognito.com';
     window.location.href = `${cognitoDomain}/logout?client_id=${clientId}&logout_uri=${encodeURIComponent(logoutUri)}`;
   };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,14 +2,15 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
-import { AuthProvider } from "react-oidc-context";
+import { AuthProvider } from 'react-oidc-context';
 
 const cognitoAuthConfig = {
-  authority: "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_gOVy1Nd3f",
-  client_id: "6853gvj2etkjscvolje3mnrifc",
-  redirect_uri: "http://localhost:5173",
-  response_type: "code",
-  scope: "email openid phone",
+  authority:
+    'https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_gOVy1Nd3f',
+  client_id: '6853gvj2etkjscvolje3mnrifc',
+  redirect_uri: 'http://localhost:5173',
+  response_type: 'code',
+  scope: 'email openid phone',
 };
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## やったこと
- CIの起動イベントを`main`ブランチへのpushからPRの作成・更新に変更
- その他
  - `eslint`の設定で対象外のファイル群（ignore）を設定
    > ローカルで一生終わらなかったため
  - `eslint`の設定で`react`のバージョンを指定
    > `warning`で出ていたため
  - `frontend/`の`formatter`で落ちていた内容を`pnpm run format:fix`で修正

## レビュー観点
- PRの作成・更新に紐づいてCIが動作していることの確認