### PR TITLE
mainにpushされた際にCDが走るように変更

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -2,17 +2,14 @@
 name: Deploy Backend to EC2
 
 on:
-  workflow_run:
-    workflows: ["CI"]      # CI ワークフローの name と合わせる
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   deploy-backend:
     name: Deploy Python Backend to EC2
     runs-on: ubuntu-latest
-    # main ブランチかつ CI 成功時のみ
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: リポジトリをチェックアウト

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,16 +2,14 @@
 name: Deploy to S3
 
 on:
-  workflow_run:
-    workflows: ["CI"] # ← CIワークフローのnameと一致
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   js:
     name: Deploy JS/TS to S3
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: リポジトリをチェックアウト


### PR DESCRIPTION
## 変更内容
front/back両CDの変更タイミングを以下の通り変更しました。

### 変更前

- 「CI」（名称は以下の`name`に対応）ワークフローが完了したタイミングかつ、ワークフローが正常終了し`main`ブランチに対して実行された場合
  - →要するに、`main`ブランチに対してCIが走り、そのCIが正常終了した時

  https://github.com/ChaSaji/aws-learn/blob/7d11c4935dbae773e2376e33282736dcc4c26d01/.github/workflows/ci.yml#L2

### 変更後

- `main`ブランチにpushされたタイミング
  - →要するに、`main`ブランチに対してPRがマージされた時（マージコミットが`main`にpushされた時）
  
### 変更理由

- `main`に直接コミットせず、作業ブランチの変更をPRを介して`main`にマージする方針で作業をするため、変更前の条件に該当するタイミングが存在しない
- PRがマージされる際はCIも成功した状態が保証されるため、`main`にマージされるタイミングで動作すればいい

## 確認方法
おそらくタイミングは問題なく動作すると思います。
CDが正常終了するかどうかは、しばらく動かしていないため不明です。

- このブランチへのコミットを一旦CDのトリガーにして、動作確認をした方がいいかもしれないです。（私）